### PR TITLE
refine pnpm settings

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+engine-strict=true
+save-exact=true

--- a/package.json
+++ b/package.json
@@ -6,6 +6,12 @@
   "license": "UNLICENSED",
   "private": true,
   "packageManager": "pnpm@7.29.1",
+  "engines": {
+    "node": "18.15.0",
+    "pnpm": "7.29.1",
+    "npm": "use pnpm instead",
+    "yarn": "use pnpm instead"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   }


### PR DESCRIPTION
<!-- Provide a general summary of your changes -->

refine pnpm settings

## Description
<!-- Describe your changes -->

- add .npmrc and set `save-exact=true` and `engine-strict=true`
  - https://docs.npmjs.com/cli/v9/using-npm/config#save-exact
  - https://docs.npmjs.com/cli/v9/using-npm/config#engine-strict
- add engines field to package.json
  - https://pnpm.io/package_json#engines

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

We only use pnpm as a package manager, so we want to prohibit the use of other package management tools.
In addition, the versions of dependencies saved in package.json should be written without the range operator (^), because Renovate requires pinned versions in package.json.

## Checklist

- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
