### PR TITLE
fix labels field at renovate.json patch field

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,6 @@
   "patch": {
     "stabilityDays": 2,
     "automerge": true,
-    "labels": ["automerge: enabled"]
+    "labels": ["dependencies", "automerge: enabled"]
   }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes -->

add `dependencies` label to `patch.labels` field

## Description

<!-- Describe your changes -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

PRs which are patch updates have only `automerge: enabled` label

## Checklist

- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
